### PR TITLE
Sets 500m as default length for individual straight_forward maps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Description:
 
 
 Options:
- - `LENGTH`: Length of the road(default 200m).
+ - `LENGTH`: Length of the road(default 500m).
  - `WIDTH`: Width of the lanes(default 3m).
  - `CROSSWALK`: Adds a 2m-width crosswalk in the middle(s=100m).(default=`False`)
  - `X_OFFSET`: X offset with respect to the origin.

--- a/resources/straight_forward/straight_forward_3_5m_width.xodr
+++ b/resources/straight_forward/straight_forward_3_5m_width.xodr
@@ -31,7 +31,7 @@
 -->
 <!--
  Map generated using:
-  - LENGTH: 200.0
+  - LENGTH: 500.0
   - WIDTH: 3.5
   - CROSSWALK: False
   - OFFSET_X: 0.0
@@ -41,11 +41,11 @@
     <header revMajor="1" revMinor="1" name="StraightRoad" version="1.00" date="Fri Apr 28 12:00:00 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
         <geoReference><![CDATA[+proj=tmerc +lat_0=37.4168716 +lon_0=-122.1030492 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ]]></geoReference>
     </header>
-    <road name="Road 1" length="200.0" id="1" junction="-1">
+    <road name="Road 1" length="500.0" id="1" junction="-1">
         <link>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="200.0">
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="500.0">
                 <line/>
             </geometry>
         </planView>

--- a/resources/straight_forward/straight_forward_3_5m_width_crosswalk.xodr
+++ b/resources/straight_forward/straight_forward_3_5m_width_crosswalk.xodr
@@ -31,7 +31,7 @@
 -->
 <!--
  Map generated using:
-  - LENGTH: 200.0
+  - LENGTH: 500.0
   - WIDTH: 3.5
   - CROSSWALK: True
   - OFFSET_X: 0.0
@@ -41,12 +41,12 @@
     <header revMajor="1" revMinor="1" name="StraightRoad" version="1.00" date="Fri Apr 28 12:00:00 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
         <geoReference><![CDATA[+proj=tmerc +lat_0=37.4168716 +lon_0=-122.1030492 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ]]></geoReference>
     </header>
-    <road name="Road 1" length="98.0" id="1" junction="-1">
+    <road name="Road 1" length="248.0" id="1" junction="-1">
         <link>
           <successor elementType="junction" elementId="2"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="98.0">
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="248.0">
                 <line/>
             </geometry>
         </planView>
@@ -94,7 +94,7 @@
             <successor elementType="road" elementId="2" contactPoint="start"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="98.0" y="0.0" hdg="0.0" length="4.0">
+            <geometry s="0.0000000000000000e+00" x="248.0" y="0.0" hdg="0.0" length="4.0">
                 <line/>
             </geometry>
         </planView>
@@ -157,7 +157,7 @@
             <successor elementType="road" elementId="2" contactPoint="start"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="98.0" y="0.0" hdg="0.0" length="4.0">
+            <geometry s="0.0000000000000000e+00" x="248.0" y="0.0" hdg="0.0" length="4.0">
                 <line/>
             </geometry>
         </planView>
@@ -214,12 +214,12 @@
         <signals>
         </signals>
     </road>
-    <road name="Road 2" length="98.0" id="2" junction="-1">
+    <road name="Road 2" length="248.0" id="2" junction="-1">
         <link>
           <predecessor elementType="junction" elementId="2"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="102.0" y="0.0" hdg="0.0" length="98.0">
+            <geometry s="0.0000000000000000e+00" x="252.0" y="0.0" hdg="0.0" length="248.0">
                 <line/>
             </geometry>
         </planView>
@@ -281,28 +281,28 @@ Generated GeoJSON can be verified using: https://geojson.io
         "coordinates": [
           [
             [
-              -122.10193085088243,
-              37.41690313036948,
+              -122.10023638252379,
+              37.416903102197395,
               0.0
             ],
             [
-              -122.10193085182026,
-              37.41684005905126,
+              -122.10023638488254,
+              37.41684003087924,
               0.0
             ],
             [
-              -122.10190825892774,
-              37.41684005883538,
+              -122.10021379199006,
+              37.41684003033954,
               0.0
             ],
             [
-              -122.10190825797098,
-              37.4169031301536,
+              -122.10021378961235,
+              37.416903101657695,
               0.0
             ],
             [
-              -122.10193085088243,
-              37.41690313036948,
+              -122.10023638252379,
+              37.416903102197395,
               0.0
             ]
           ]

--- a/resources/straight_forward/straight_forward_3m_width.xodr
+++ b/resources/straight_forward/straight_forward_3m_width.xodr
@@ -31,7 +31,7 @@
 -->
 <!--
  Map generated using:
-  - LENGTH: 200.0
+  - LENGTH: 500.0
   - WIDTH: 3.0
   - CROSSWALK: False
   - OFFSET_X: 0.0
@@ -41,11 +41,11 @@
     <header revMajor="1" revMinor="1" name="StraightRoad" version="1.00" date="Fri Apr 28 12:00:00 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
         <geoReference><![CDATA[+proj=tmerc +lat_0=37.4168716 +lon_0=-122.1030492 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ]]></geoReference>
     </header>
-    <road name="Road 1" length="200.0" id="1" junction="-1">
+    <road name="Road 1" length="500.0" id="1" junction="-1">
         <link>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="200.0">
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="500.0">
                 <line/>
             </geometry>
         </planView>

--- a/resources/straight_forward/straight_forward_3m_width_crosswalk.xodr
+++ b/resources/straight_forward/straight_forward_3m_width_crosswalk.xodr
@@ -31,7 +31,7 @@
 -->
 <!--
  Map generated using:
-  - LENGTH: 200.0
+  - LENGTH: 500.0
   - WIDTH: 3.0
   - CROSSWALK: True
   - OFFSET_X: 0.0
@@ -41,12 +41,12 @@
     <header revMajor="1" revMinor="1" name="StraightRoad" version="1.00" date="Fri Apr 28 12:00:00 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
         <geoReference><![CDATA[+proj=tmerc +lat_0=37.4168716 +lon_0=-122.1030492 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ]]></geoReference>
     </header>
-    <road name="Road 1" length="98.0" id="1" junction="-1">
+    <road name="Road 1" length="248.0" id="1" junction="-1">
         <link>
           <successor elementType="junction" elementId="2"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="98.0">
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="248.0">
                 <line/>
             </geometry>
         </planView>
@@ -94,7 +94,7 @@
             <successor elementType="road" elementId="2" contactPoint="start"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="98.0" y="0.0" hdg="0.0" length="4.0">
+            <geometry s="0.0000000000000000e+00" x="248.0" y="0.0" hdg="0.0" length="4.0">
                 <line/>
             </geometry>
         </planView>
@@ -157,7 +157,7 @@
             <successor elementType="road" elementId="2" contactPoint="start"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="98.0" y="0.0" hdg="0.0" length="4.0">
+            <geometry s="0.0000000000000000e+00" x="248.0" y="0.0" hdg="0.0" length="4.0">
                 <line/>
             </geometry>
         </planView>
@@ -214,12 +214,12 @@
         <signals>
         </signals>
     </road>
-    <road name="Road 2" length="98.0" id="2" junction="-1">
+    <road name="Road 2" length="248.0" id="2" junction="-1">
         <link>
           <predecessor elementType="junction" elementId="2"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="102.0" y="0.0" hdg="0.0" length="98.0">
+            <geometry s="0.0000000000000000e+00" x="252.0" y="0.0" hdg="0.0" length="248.0">
                 <line/>
             </geometry>
         </planView>
@@ -281,28 +281,28 @@ Generated GeoJSON can be verified using: https://geojson.io
         "coordinates": [
           [
             [
-              -122.10193085094943,
-              37.41689862527534,
+              -122.10023638269226,
+              37.41689859710327,
               0.0
             ],
             [
-              -122.10193085175327,
-              37.41684456414544,
+              -122.10023638471405,
+              37.41684453597342,
               0.0
             ],
             [
-              -122.1019082588594,
-              37.41684456392955,
+              -122.10021379182022,
+              37.41684453543372,
               0.0
             ],
             [
-              -122.10190825803932,
-              37.41689862505946,
+              -122.1002137897822,
+              37.41689859656357,
               0.0
             ],
             [
-              -122.10193085094943,
-              37.41689862527534,
+              -122.10023638269226,
+              37.41689859710327,
               0.0
             ]
           ]

--- a/resources/straight_forward/straight_forward_4m_width.xodr
+++ b/resources/straight_forward/straight_forward_4m_width.xodr
@@ -31,7 +31,7 @@
 -->
 <!--
  Map generated using:
-  - LENGTH: 200.0
+  - LENGTH: 500.0
   - WIDTH: 4.0
   - CROSSWALK: False
   - OFFSET_X: 0.0
@@ -41,11 +41,11 @@
     <header revMajor="1" revMinor="1" name="StraightRoad" version="1.00" date="Fri Apr 28 12:00:00 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
         <geoReference><![CDATA[+proj=tmerc +lat_0=37.4168716 +lon_0=-122.1030492 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ]]></geoReference>
     </header>
-    <road name="Road 1" length="200.0" id="1" junction="-1">
+    <road name="Road 1" length="500.0" id="1" junction="-1">
         <link>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="200.0">
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="500.0">
                 <line/>
             </geometry>
         </planView>

--- a/resources/straight_forward/straight_forward_4m_width_crosswalk.xodr
+++ b/resources/straight_forward/straight_forward_4m_width_crosswalk.xodr
@@ -31,7 +31,7 @@
 -->
 <!--
  Map generated using:
-  - LENGTH: 200.0
+  - LENGTH: 500.0
   - WIDTH: 4.0
   - CROSSWALK: True
   - OFFSET_X: 0.0
@@ -41,12 +41,12 @@
     <header revMajor="1" revMinor="1" name="StraightRoad" version="1.00" date="Fri Apr 28 12:00:00 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
         <geoReference><![CDATA[+proj=tmerc +lat_0=37.4168716 +lon_0=-122.1030492 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ]]></geoReference>
     </header>
-    <road name="Road 1" length="98.0" id="1" junction="-1">
+    <road name="Road 1" length="248.0" id="1" junction="-1">
         <link>
           <successor elementType="junction" elementId="2"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="98.0">
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="248.0">
                 <line/>
             </geometry>
         </planView>
@@ -94,7 +94,7 @@
             <successor elementType="road" elementId="2" contactPoint="start"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="98.0" y="0.0" hdg="0.0" length="4.0">
+            <geometry s="0.0000000000000000e+00" x="248.0" y="0.0" hdg="0.0" length="4.0">
                 <line/>
             </geometry>
         </planView>
@@ -157,7 +157,7 @@
             <successor elementType="road" elementId="2" contactPoint="start"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="98.0" y="0.0" hdg="0.0" length="4.0">
+            <geometry s="0.0000000000000000e+00" x="248.0" y="0.0" hdg="0.0" length="4.0">
                 <line/>
             </geometry>
         </planView>
@@ -214,12 +214,12 @@
         <signals>
         </signals>
     </road>
-    <road name="Road 2" length="98.0" id="2" junction="-1">
+    <road name="Road 2" length="248.0" id="2" junction="-1">
         <link>
           <predecessor elementType="junction" elementId="2"/>
         </link>
         <planView>
-            <geometry s="0.0000000000000000e+00" x="102.0" y="0.0" hdg="0.0" length="98.0">
+            <geometry s="0.0000000000000000e+00" x="252.0" y="0.0" hdg="0.0" length="248.0">
                 <line/>
             </geometry>
         </planView>
@@ -281,28 +281,28 @@ Generated GeoJSON can be verified using: https://geojson.io
         "coordinates": [
           [
             [
-              -122.10193085081544,
-              37.41690763546362,
+              -122.10023638235529,
+              37.416907607291535,
               0.0
             ],
             [
-              -122.10193085188723,
-              37.41683555395708,
+              -122.10023638505103,
+              37.41683552578506,
               0.0
             ],
             [
-              -122.10190825899608,
-              37.41683555374119,
+              -122.10021379215988,
+              37.41683552524536,
               0.0
             ],
             [
-              -122.10190825790264,
-              37.41690763524773,
+              -122.10021378944252,
+              37.41690760675183,
               0.0
             ],
             [
-              -122.10193085081544,
-              37.41690763546362,
+              -122.10023638235529,
+              37.416907607291535,
               0.0
             ]
           ]

--- a/templates/straight_forward.xml.em
+++ b/templates/straight_forward.xml.em
@@ -43,7 +43,7 @@ def str2bool(string):
 def str2float(string):
   return float(string)
 
-length = str2float(os.environ['LENGTH']) if 'LENGTH' in os.environ  else 200.0
+length = str2float(os.environ['LENGTH']) if 'LENGTH' in os.environ  else 500.0
 x_offset = str2float(os.environ['X_OFFSET']) if 'X_OFFSET' in os.environ  else 0.0
 y_offset = str2float(os.environ['Y_OFFSET']) if 'Y_OFFSET' in os.environ  else 0.0
 width = str2float(os.environ['WIDTH']) if 'WIDTH' in os.environ  else 3.0


### PR DESCRIPTION
# 🎉 New feature

## Summary
Modifies the default length of the straight road for both crosswalk and non-crosswalk versions.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

