### PR TITLE
Add HasOncomingTraffic property to GeoJSON file

### DIFF
--- a/resources/intersection/intersection_3_3m_width_6m_radius_stopline.geojson
+++ b/resources/intersection/intersection_3_3m_width_6m_radius_stopline.geojson
@@ -1,6 +1,38 @@
 {
+  "_comment": "Features of type 'hasOncomingTraffic' are temporary hints and ignored by Maliput.",
   "features": [
-
+    {
+      "properties": {
+        "Id": "9_0_1",
+        "Type": "Lane",
+        "HasOncomingTraffic": true
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "Id": "8_0_1",
+        "Type": "Lane",
+        "HasOncomingTraffic": true
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "Id": "7_0_-1",
+        "Type": "Lane",
+        "HasOncomingTraffic": true
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "Id": "10_0_-1",
+        "Type": "Lane",
+        "HasOncomingTraffic": true
+      },
+      "type": "Feature"
+    },
     {
       "geometry": {
         "coordinates": [


### PR DESCRIPTION
Modify intersection_3_3m_width_6m_radius_stopline.geojson to include information about whether a lane has oncoming traffic.
# 🎉 New feature

## Summary

In our downstream project, there is a need to provide a "hint" regarding whether a lane has oncoming traffic. This is a proposal on how such a hint can be provided. One thing we are not sure about is whether it is okay to reference a lane ID like "9_0_-1" in the GeoJSON file since such a lane ID doesn't actually exist in the corresponding XODR (it is derived at load time). Thoughts?
